### PR TITLE
Rendering strings with escapes (for newlines, quotes, etc)

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports.pretty = function (jsObject, indentLength, outputTo, fullFunction
                 return fromArray + '{' + newLine + prettyObject(element, indent) + indent + '}';
 
             case 'string':
-                return fromArray + '"' + element + '"';
+                return fromArray + JSON.stringify(element);
 
             case 'function':
                 return fromArray + functionSignature(element);

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ address = { 'street': 'Callejon de las ranas 128', 'city': 'Falfurrias', 'state'
 value = {
     'name': 'Damaso Infanzon Manzo',
     'address': address,
+    'longString': "one\ntwo\n\"three\"",
     'favorites': { 'music': ['Mozart', 'Beethoven', 'The Beatles'],  'authors': ['John Grisham', 'Isaac Asimov', 'P.L. Travers'], 'books': [ 'Pelican Brief', 'I, Robot', 'Mary Poppins' ] },
     'dates': [ new Date(), new Date("05/25/1954") ],
     'numbers': [ 10, 883, 521 ],
@@ -85,6 +86,10 @@ describe('Object serialized for print', function () {
     it('Functions found', function () {
         assert.notEqual(serialized.indexOf('onWhatever: "function (foo, bar)"'), -1);
         assert.notEqual(serialized.indexOf('onAnother: "function onAnother(foo, bar)"'), -1);
+    });
+
+    it('renders strings with escapes', function () {
+        assert.notEqual(serialized.indexOf('longString: "one\\ntwo\\n\\"three\\""'), -1);
     });
 });
 


### PR DESCRIPTION
There are a few potential gotchas with this, if we place newlines in strings `\n`, then they are rendered as real newlines, which aren't valid JS. Also, double quotes `"` aren't escaped so they produce invalid JS too. I've fixed by using `JSON.stringify` on strings, which is a fairly reliable and easy way to escape strings in these situations. Test included :)