### PR TITLE
Prettier output of empty objects (no newline)

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,9 @@ module.exports.pretty = function (jsObject, indentLength, outputTo, fullFunction
 
             case 'object':
                 visited.push(element);
+                if (Object.keys(element).length === 0) {
+                    return fromArray + '{ }';
+                }
                 return fromArray + '{' + newLine + prettyObject(element, indent) + indent + '}';
 
             case 'string':


### PR DESCRIPTION
Encountered a situation where empty objects were outputted as:
```javascript
{
  somekey: {
      
  }
}
```

..whereas I would prefer it like so:
```javascript
{
  somekey: { }
}
```

This is a quick PR to correct that.